### PR TITLE
Fix timezone mapping for Indiana area code 219

### DIFF
--- a/src/utils/timezoneUtils.ts
+++ b/src/utils/timezoneUtils.ts
@@ -22,7 +22,8 @@ const AREA_CODE_MAP: {
   '216': { state: 'OH', timezone: 'America/New_York' },
   '217': { state: 'IL', timezone: 'America/Chicago' },
   '218': { state: 'MN', timezone: 'America/Chicago' },
-  '219': { state: 'IN', timezone: 'America/New_York' },
+  // Northwest Indiana uses Central time
+  '219': { state: 'IN', timezone: 'America/Chicago' },
   '224': { state: 'IL', timezone: 'America/Chicago' },
   '225': { state: 'LA', timezone: 'America/Chicago' },
   '228': { state: 'MS', timezone: 'America/Chicago' },


### PR DESCRIPTION
## Summary
- correct the timezone mapping for area code `219` in `timezoneUtils`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_687ffa7dbe088320b6ab5b967adee240