### PR TITLE
Fix placeholder replacements and add company placeholder

### DIFF
--- a/src/hooks/useLeadCardActions.ts
+++ b/src/hooks/useLeadCardActions.ts
@@ -39,16 +39,18 @@ export const useLeadCardActions = (lead: Lead) => {
       
       // Replace placeholders in template
       const subject = template.subject
-        .replace('{name}', lead.name)
-        .replace('{company}', lead.company || '')
-        .replace('{{first_name}}', firstName)
-        .replace('{{last_name}}', lastName);
+        .replace(/{name}/g, lead.name)
+        .replace(/{company}/g, lead.company || '')
+        .replace(/{{\s*first_name\s*}}/gi, firstName)
+        .replace(/{{\s*last_name\s*}}/gi, lastName)
+        .replace(/{{\s*company\s*}}/gi, lead.company || '');
       const body = template.body
-        .replace('{name}', lead.name)
-        .replace('{company}', lead.company || '')
-        .replace('{phone}', selectedPhone)
-        .replace('{{first_name}}', firstName)
-        .replace('{{last_name}}', lastName);
+        .replace(/{name}/g, lead.name)
+        .replace(/{company}/g, lead.company || '')
+        .replace(/{phone}/g, selectedPhone)
+        .replace(/{{\s*first_name\s*}}/gi, firstName)
+        .replace(/{{\s*last_name\s*}}/gi, lastName)
+        .replace(/{{\s*company\s*}}/gi, lead.company || '');
         
       return `mailto:${emailValue}?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
     }
@@ -65,10 +67,11 @@ export const useLeadCardActions = (lead: Lead) => {
       const { firstName, lastName } = parseName(lead.name);
       
       const message = template.message
-        .replace('{name}', lead.name)
-        .replace('{company}', lead.company || '')
-        .replace('{{first_name}}', firstName)
-        .replace('{{last_name}}', lastName);
+        .replace(/{name}/g, lead.name)
+        .replace(/{company}/g, lead.company || '')
+        .replace(/{{\s*first_name\s*}}/gi, firstName)
+        .replace(/{{\s*last_name\s*}}/gi, lastName)
+        .replace(/{{\s*company\s*}}/gi, lead.company || '');
         
       return `sms:${cleanPhone}?body=${encodeURIComponent(message)}`;
     }


### PR DESCRIPTION
## Summary
- use regex to replace name placeholders in lead card actions
- support first/last name and company substitutions in templates

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: React Hook "useEffect" cannot be called inside a callback in src/hooks/useAutoCall.ts)*
- `npx eslint src/hooks/useLeadCardActions.ts`


------
https://chatgpt.com/codex/tasks/task_e_6890fb8d949883208737f6335a1cf4e5