### PR TITLE
Fix csv selector bullet alignment

### DIFF
--- a/src/components/CSVFileSelector.tsx
+++ b/src/components/CSVFileSelector.tsx
@@ -314,11 +314,13 @@ const CSVFileSelector: React.FC<CSVFileSelectorProps> = ({
               >
                 <div className="flex items-baseline justify-between w-full">
                   <div className="flex flex-col items-start flex-1 min-w-0 pr-2">
-                    <div className="flex items-baseline">
-                      {file.id === currentCSVId && (
-                        <div className="w-2 h-2 bg-foreground rounded-full mr-2 flex-shrink-0"></div>
-                      )}
-                      <span className="font-normal truncate text-base block max-w-[200px]" title={file.name}>{file.name}</span>
+                    <div className="flex items-baseline w-full">
+                      <div className="flex items-center min-w-0 flex-1">
+                        {file.id === currentCSVId && (
+                          <div className="w-2 h-2 bg-foreground rounded-full mr-2 flex-shrink-0 mt-0.5"></div>
+                        )}
+                        <span className="font-normal truncate text-base block flex-1" title={file.name}>{file.name}</span>
+                      </div>
                     </div>
                     <div className="flex items-baseline mt-0.5">
                       <span className="text-sm text-muted-foreground">


### PR DESCRIPTION
Improve layout of the selected CSV file bullet to prevent text overflow and ensure proper truncation.

Previously, the bullet's `flex-shrink-0` and `mr-2` properties caused it to push the file name text to the right, leading to truncation issues. The updated layout ensures the bullet and text coexist properly within the available space.

---
<a href="https://cursor.com/background-agent?bcId=bc-9ba43a9c-2fb4-4d9d-aa22-c61cdf2ecad0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9ba43a9c-2fb4-4d9d-aa22-c61cdf2ecad0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

