### PR TITLE
Fix storage manager get email subject error

### DIFF
--- a/src/hooks/useLeadCardTemplates.ts
+++ b/src/hooks/useLeadCardTemplates.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useAppVisibility } from "../hooks/useAppVisibility";
+import { StorageManager } from '@/utils/storageManager';
 
 interface EmailTemplate {
   id: string;


### PR DESCRIPTION
Add missing `StorageManager` import to `useLeadCardTemplates.ts` to resolve 'storagemanager.getemailsubject is not a function' error during lead list import.

---
<a href="https://cursor.com/background-agent?bcId=bc-7ed9ce0d-3d01-4214-8462-45c64c7230e1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7ed9ce0d-3d01-4214-8462-45c64c7230e1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

