### PR TITLE
Hide search input cursor until typing

### DIFF
--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -222,10 +222,10 @@ const SearchBar = forwardRef<SearchBarRef, SearchBarProps>(({
         onClick={handleInputClick}
         onTouchStart={handleTouchStart}
         enterKeyHint="done"
-        className={`w-full py-2 bg-card text-card-foreground rounded-xl border border-border placeholder:text-center placeholder:text-muted-foreground text-center focus:border-primary/50 focus:bg-card shadow-sm ${!hasStartedTyping && isFocused ? 'caret-transparent' : ''}`}
+        className={`w-full py-2 bg-card text-card-foreground rounded-xl border border-border placeholder:text-center placeholder:text-muted-foreground text-center focus:border-primary/50 focus:bg-card shadow-sm ${!hasStartedTyping ? 'caret-transparent' : ''}`}
         ref={inputRef}
         style={{
-          caretColor: (!hasStartedTyping && isFocused) ? 'transparent' : 'auto',
+          caretColor: (!hasStartedTyping) ? 'transparent' : 'auto',
           paddingLeft: '2.5rem',
           paddingRight: searchQuery ? '2.5rem' : '1rem'
         }}


### PR DESCRIPTION
Hide caret in search input until typing begins to prevent brief flicker on focus.

---
<a href="https://cursor.com/background-agent?bcId=bc-b24615b6-19f8-463c-aae8-e764776d6f69">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b24615b6-19f8-463c-aae8-e764776d6f69">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

