### PR TITLE
Find all template placeholders

### DIFF
--- a/src/hooks/useLeadCardActions.ts
+++ b/src/hooks/useLeadCardActions.ts
@@ -39,15 +39,10 @@ export const useLeadCardActions = (lead: Lead) => {
       
       // Replace placeholders in template
       const subject = template.subject
-        .replace(/{name}/g, lead.name)
-        .replace(/{company}/g, lead.company || '')
         .replace(/{{\s*first_name\s*}}/gi, firstName)
         .replace(/{{\s*last_name\s*}}/gi, lastName)
         .replace(/{{\s*company\s*}}/gi, lead.company || '');
       const body = template.body
-        .replace(/{name}/g, lead.name)
-        .replace(/{company}/g, lead.company || '')
-        .replace(/{phone}/g, selectedPhone)
         .replace(/{{\s*first_name\s*}}/gi, firstName)
         .replace(/{{\s*last_name\s*}}/gi, lastName)
         .replace(/{{\s*company\s*}}/gi, lead.company || '');
@@ -67,8 +62,6 @@ export const useLeadCardActions = (lead: Lead) => {
       const { firstName, lastName } = parseName(lead.name);
       
       const message = template.message
-        .replace(/{name}/g, lead.name)
-        .replace(/{company}/g, lead.company || '')
         .replace(/{{\s*first_name\s*}}/gi, firstName)
         .replace(/{{\s*last_name\s*}}/gi, lastName)
         .replace(/{{\s*company\s*}}/gi, lead.company || '');

--- a/src/hooks/useLeadCardActions.ts
+++ b/src/hooks/useLeadCardActions.ts
@@ -37,15 +37,15 @@ export const useLeadCardActions = (lead: Lead) => {
       // Parse name into first and last name
       const { firstName, lastName } = parseName(lead.name);
       
-      // Replace placeholders in template
+      // Replace placeholders in template (single-brace)
       const subject = template.subject
-        .replace(/{{\s*first_name\s*}}/gi, firstName)
-        .replace(/{{\s*last_name\s*}}/gi, lastName)
-        .replace(/{{\s*company\s*}}/gi, lead.company || '');
+        .replace(/\{\s*first_name\s*\}/gi, firstName)
+        .replace(/\{\s*last_name\s*\}/gi, lastName)
+        .replace(/\{\s*company\s*\}/gi, lead.company || '');
       const body = template.body
-        .replace(/{{\s*first_name\s*}}/gi, firstName)
-        .replace(/{{\s*last_name\s*}}/gi, lastName)
-        .replace(/{{\s*company\s*}}/gi, lead.company || '');
+        .replace(/\{\s*first_name\s*\}/gi, firstName)
+        .replace(/\{\s*last_name\s*\}/gi, lastName)
+        .replace(/\{\s*company\s*\}/gi, lead.company || '');
         
       return `mailto:${emailValue}?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
     }
@@ -62,9 +62,9 @@ export const useLeadCardActions = (lead: Lead) => {
       const { firstName, lastName } = parseName(lead.name);
       
       const message = template.message
-        .replace(/{{\s*first_name\s*}}/gi, firstName)
-        .replace(/{{\s*last_name\s*}}/gi, lastName)
-        .replace(/{{\s*company\s*}}/gi, lead.company || '');
+        .replace(/\{\s*first_name\s*\}/gi, firstName)
+        .replace(/\{\s*last_name\s*\}/gi, lastName)
+        .replace(/\{\s*company\s*\}/gi, lead.company || '');
         
       return `sms:${cleanPhone}?body=${encodeURIComponent(message)}`;
     }


### PR DESCRIPTION
Standardize template placeholders to use single braces and remove deprecated ones.

---
<a href="https://cursor.com/background-agent?bcId=bc-070e5274-f6f7-4ee2-982c-786b50357dc5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-070e5274-f6f7-4ee2-982c-786b50357dc5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

