### PR TITLE
Fix duplicate cards with updated status

### DIFF
--- a/src/hooks/useLeadSelection.ts
+++ b/src/hooks/useLeadSelection.ts
@@ -55,7 +55,17 @@ export const useLeadSelection = () => {
     } else {
       // All leads have been shown, pick any random lead (cycle complete)
       console.log('All leads have been shown, cycling complete - picking any random lead');
-      const randomIndex = Math.floor(Math.random() * baseLeads.length);
+      if (baseLeads.length === 1) {
+        return {
+          index: currentIndex,
+          lead: baseLeads[currentIndex]
+        };
+      }
+      let randomIndex = Math.floor(Math.random() * baseLeads.length);
+      // Avoid reselecting the current lead if possible
+      if (randomIndex === currentIndex && baseLeads.length > 1) {
+        randomIndex = (randomIndex + 1) % baseLeads.length;
+      }
       return {
         index: randomIndex,
         lead: baseLeads[randomIndex]

--- a/src/hooks/useNavigation.ts
+++ b/src/hooks/useNavigation.ts
@@ -54,16 +54,16 @@ export const useNavigation = (
     let nextIndex: number;
     
     if (shuffleMode) {
-      const result = getNextLeadInShuffle(baseLeads, currentIndex, callFilter, shownLeadsInShuffle);
-      nextIndex = result.index;
-      
-      // Add the current lead to shown leads in shuffle
+      // Add the current lead to shown leads in shuffle BEFORE picking the next one
       if (currentLead) {
         const leadKey = `${currentLead.name}-${currentLead.phone}`;
         const newShownLeads = new Set(shownLeadsInShuffle);
         newShownLeads.add(leadKey);
         setShownLeadsInShuffle(newShownLeads);
       }
+
+      const result = getNextLeadInShuffle(baseLeads, currentIndex, callFilter, shownLeadsInShuffle);
+      nextIndex = result.index;
       
       // Use history-aware navigation for shuffle mode
       updateNavigationWithHistory(nextIndex, true);


### PR DESCRIPTION
Prevent the same card from reappearing immediately when pressing "Next" in shuffle mode.

Previously, the current lead could be re-selected, especially when cycling through all leads or if it wasn't immediately marked as "shown" before the next lead was picked. This led to the perception of a duplicate card with only the `lastCalled` status updated.

---
<a href="https://cursor.com/background-agent?bcId=bc-dfe669df-e507-4337-a0b9-0a280dd4fb6f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-dfe669df-e507-4337-a0b9-0a280dd4fb6f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

