### PR TITLE
Fix duplicate card display after call

### DIFF
--- a/src/hooks/useNavigation.ts
+++ b/src/hooks/useNavigation.ts
@@ -60,8 +60,17 @@ export const useNavigation = (
         const newShownLeads = new Set(shownLeadsInShuffle);
         newShownLeads.add(leadKey);
         setShownLeadsInShuffle(newShownLeads);
+        
+        // Use the updated set when selecting the next lead to avoid reselecting the same card
+        const result = getNextLeadInShuffle(baseLeads, currentIndex, callFilter, newShownLeads);
+        nextIndex = result.index;
+        
+        // Use history-aware navigation for shuffle mode
+        updateNavigationWithHistory(nextIndex, true);
+        return;
       }
 
+      // Fallback if no current lead
       const result = getNextLeadInShuffle(baseLeads, currentIndex, callFilter, shownLeadsInShuffle);
       nextIndex = result.index;
       


### PR DESCRIPTION
Prevent the same lead from reappearing after pressing "Next" in shuffle mode.

The previous logic for shuffle mode calculated the next lead using an outdated set of `shownLeadsInShuffle`, which did not yet include the lead just marked as called, leading to the possibility of the same card being reselected. This fix updates the set *before* determining the next lead.

---
<a href="https://cursor.com/background-agent?bcId=bc-da602010-c1f1-49fc-a2eb-4001a5ca86e0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-da602010-c1f1-49fc-a2eb-4001a5ca86e0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

