### PR TITLE
Center comment view above iOS keyboard

### DIFF
--- a/src/components/LeadCard.tsx
+++ b/src/components/LeadCard.tsx
@@ -39,6 +39,8 @@ interface LeadCardProps {
   onImportNew?: () => void;
   navigationDirection?: 'forward' | 'backward';
   onSwipeReset?: (resetSwipe: () => void) => void;
+  onCommentingChange?: (commenting: boolean) => void;
+  isCommenting?: boolean;
 }
 
 const LeadCard: React.FC<LeadCardProps> = ({
@@ -55,7 +57,9 @@ const LeadCard: React.FC<LeadCardProps> = ({
   refreshTrigger,
   onImportNew,
   navigationDirection = 'forward',
-  onSwipeReset
+  onSwipeReset,
+  onCommentingChange,
+  isCommenting
 }) => {
   // Use the extracted hooks
   const {
@@ -107,6 +111,20 @@ const LeadCard: React.FC<LeadCardProps> = ({
   const [addFxVisible, setAddFxVisible] = useState(false);
   const [selectedCommentId, setSelectedCommentId] = useState<string | null>(null);
   const [leadTag, setLeadTagState] = useState<'cold' | 'warm' | 'hot' | null>(null);
+
+  const handleCommentFocus = useCallback(() => {
+    onCommentingChange?.(true);
+  }, [onCommentingChange]);
+
+  const handleCommentBlur = useCallback(() => {
+    onCommentingChange?.(false);
+  }, [onCommentingChange]);
+
+  useEffect(() => {
+    if (!isCardFlipped) {
+      onCommentingChange?.(false);
+    }
+  }, [isCardFlipped, onCommentingChange]);
   
   // Subtle neon backlight color based on lead tag
   const glowColor = useMemo(() => {
@@ -1123,6 +1141,8 @@ const LeadCard: React.FC<LeadCardProps> = ({
               value={draft}
               onChange={(e) => setDraft(e.target.value)}
               ref={commentInputRef}
+              onFocus={handleCommentFocus}
+              onBlur={handleCommentBlur}
               className="flex-1 rounded-md border border-border/30 bg-background px-3 text-sm focus:outline-none h-11 resize-none py-2 text-left placeholder:text-left"
               rows={1}
               placeholder="Add a comment..."

--- a/src/components/MainContent.tsx
+++ b/src/components/MainContent.tsx
@@ -155,10 +155,13 @@ const MainContent: React.FC<MainContentProps> = ({
   }, [isCommenting]);
 
   return (
-    <div className={`flex-1 flex items-start justify-center min-h-0 transition-all duration-300 ${isCommenting ? 'pt-0 p-2 h-full overflow-hidden' : 'pt-1 p-3 sm:p-4'}`} style={{ minHeight: isCommenting ? undefined : 'calc(100dvh - 120px)', height: isCommenting ? (viewportHeight ? `${viewportHeight}px` : '100vh') : undefined }}>
-      <div className="w-full space-y-1 flex flex-col min-h-full">
+    <div
+      className={`flex-1 flex ${isCommenting ? 'items-center' : 'items-start'} justify-center min-h-0 transition-all duration-300 ${isCommenting ? 'pt-0 p-2 h-full overflow-hidden' : 'pt-1 p-3 sm:p-4'}`}
+      style={{ minHeight: isCommenting ? undefined : 'calc(100dvh - 120px)', height: isCommenting ? (viewportHeight ? `${viewportHeight}px` : '100vh') : undefined }}
+    >
+      <div className={`w-full space-y-1 flex flex-col ${isCommenting ? '' : 'min-h-full'}`}>
         {/* Filter Buttons */}
-        <div className={`transition-all duration-300 ease-out ${isCommenting ? 'opacity-0 scale-95 -translate-y-2 pointer-events-none' : ''}`}>
+        <div className={`transition-all duration-300 ease-out ${isCommenting ? 'opacity-0 scale-95 -translate-y-2 pointer-events-none hidden' : ''}`}>
           <FilterButtons
             timezoneFilter={timezoneFilter}
             callFilter={callFilter}
@@ -179,7 +182,7 @@ const MainContent: React.FC<MainContentProps> = ({
         </div>
 
         {/* Current Lead Card or No Leads Message */}
-        <div className="animate-content-change-fast flex-1 flex flex-col">
+        <div className={`animate-content-change-fast ${isCommenting ? '' : 'flex-1'} flex flex-col`}>
           <LeadCard
             lead={currentLead}
             currentIndex={currentIndex}
@@ -201,7 +204,7 @@ const MainContent: React.FC<MainContentProps> = ({
         </div>
 
         {/* Navigation Controls */}
-        <div className={`pt-3 sm:pt-4 transition-all duration-300 ease-out ${isCommenting ? 'opacity-0 scale-95 translate-y-2 pointer-events-none' : ''}`}>
+        <div className={`pt-3 sm:pt-4 transition-all duration-300 ease-out ${isCommenting ? 'opacity-0 scale-95 translate-y-2 pointer-events-none hidden' : ''}`}>
           <NavigationControls
             onPrevious={handlePrevious}
             onNext={handleNext}


### PR DESCRIPTION
## Summary
- Center lead card when adding comments by hiding surrounding UI during commenting
- Notify parent when comment input focuses or blurs so viewport height recalculates on iOS

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_689d45a161e483208e6dbcae62d7d011