### PR TITLE
fix: handle viewport height with visualViewport

### DIFF
--- a/src/components/MainContent.tsx
+++ b/src/components/MainContent.tsx
@@ -180,7 +180,7 @@ const MainContent: React.FC<MainContentProps> = ({
   // Calculate positioning to place card 12px above keyboard on iOS
   // Keep container full-height and use bottom padding to lift content above the keyboard
   const commentingStyle = isCommenting ? {
-    height: '100vh',
+    height: viewportHeight ? `${viewportHeight}px` : '100dvh',
     overflow: 'hidden',
     paddingBottom: `${Math.max(0, keyboardHeight + 18)}px`,
     transition: 'padding-bottom 0.18s ease-out',


### PR DESCRIPTION
## Summary
- replace fixed 100vh style with visualViewport-aware height fallback
- keep content centered by recalculating viewport height when commenting

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 7 errors, 19 warnings)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689e2d89a28083208809b862bdf43324