### PR TITLE
Center comment input scroll to prevent card jump

### DIFF
--- a/src/components/LeadCard.tsx
+++ b/src/components/LeadCard.tsx
@@ -1168,7 +1168,7 @@ const LeadCard: React.FC<LeadCardProps> = ({
                   e.currentTarget.style.scrollMarginBottom = `calc(${bottomOverlay}px + env(safe-area-inset-bottom) + 12px)`;
                   // Ensure the textarea is positioned above the accessory bar
                   setTimeout(() => {
-                    e.currentTarget.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+                  e.currentTarget.scrollIntoView({ block: 'center', behavior: 'smooth' });
                   }, 50);
                 } catch {
                   /* ignore */


### PR DESCRIPTION
## Summary
- Center scroll to comment input so card doesn't fly to top when adding a comment

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 7 errors, 19 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_689e314cb0508320b6725530c032ba75